### PR TITLE
Version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Initial Release
+
+## 0.1.0 - 2018-03-25
+- Initial release
 
 <!-- Update the Unreleased comparison range with each release -->
-[Unreleased]: https://github.com/CondeNast/perf-timeline/compare/x.y.z...master
+[Unreleased]: https://github.com/CondeNast/perf-timeline/compare/0.1.0..master

--- a/package.json
+++ b/package.json
@@ -37,6 +37,5 @@
     "eslint-plugin-import": "^2.9.0",
     "jest": "^22.4.3",
     "sinon": "^4.4.8"
-  },
-  "private": true
+  }
 }


### PR DESCRIPTION
The PR tracks the initial release of the project. I'm marking it 0.1.0 as we are just getting warmed up with this project.

This PR updates the CHANGLELOG.md and removes the `private` flag. If there are any other pre-release items that need to be addressed, they will be handled here.