### PR TITLE
Remove spread operator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 language: node_js
 node_js:
+  - "8.0.0"
   - "8"
+  - "lts/*"
   - "9"
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+* Remove spread operator as it causes an error to be thrown for Node 8.2.x and lower
+([#10](https://github.com/CondeNast/perf-timeline-cli/issues/10))
+
 ## [0.1.2] - 2018-03-26
 
 ### Added

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -68,7 +68,9 @@ internals.generate = async (url = '', options = {}) => {
 };
 
 const handler = (argv = {}) => {
-  const { url, ...options } = argv;
+  const options = Object.assign({}, argv);
+  const { url } = options;
+  delete options.url;
   internals.generate(url, options);
 };
 


### PR DESCRIPTION
This project promises compatibility for Node 8+. Unfortunately, it appears that Node 8.0.x, 8.1.x, and 8.2.x do not support the spread operator. Running the `generate` command on those Node version throws an error. This commit removes the spread operator to honor that promise.

There isn't a test that could have been written to find this problem. Rather, we need to be testing in different versions of Node. This commit also adds new versions of Node to test.

Issue originally reported in #6.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
