### PR TITLE
Add --viewport-size option

### DIFF
--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -33,7 +33,22 @@ const OPTIONS = {
     describe: 'Whether to run browser in headless mode',
     group: 'Launch'
   },
-
+  // Page configuration
+  'viewport-size': {
+    default: null,
+    type: 'string',
+    describe: 'Viewport size. Format: WIDTHxHEIGHT',
+    group: 'Page',
+    coerce: (viewportSize) => {
+      if (viewportSize) {
+        const viewportDimensions = viewportSize.split('x');
+        const width = parseInt(viewportDimensions[0], 10);
+        const height = parseInt(viewportDimensions[1], 10);
+        return { width, height };
+      }
+      return null;
+    }
+  },
   // Network emulation options
   'emulate-network-conditions': {
     default: false,

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -13,6 +13,10 @@ internals.generate = async (url = '', options = {}) => {
   });
   const page = await browser.newPage();
 
+  if (options.viewportSize) {
+    await page.setViewport(options.viewportSize);
+  }
+
   if (options.emulateNetworkConditions === true) {
     const command = client.buildCommand('NETWORK', 'EMULATE_NETWORK_CONDITIONS');
 

--- a/test/src/commands/generate/handler.spec.js
+++ b/test/src/commands/generate/handler.spec.js
@@ -24,7 +24,8 @@ describe('src/commands/generate/handler', () => {
           start: sandbox.stub().resolves(),
           stop: sandbox.stub().resolves()
         },
-        goto: sandbox.stub().resolves()
+        goto: sandbox.stub().resolves(),
+        setViewport: sandbox.stub().resolves()
       };
       browser = {
         newPage: sandbox.stub().resolves(page),
@@ -225,6 +226,18 @@ describe('src/commands/generate/handler', () => {
 
         await internals.generate(url, options);
         expect(page.goto.calledOnceWith(url, options)).toBe(true);
+      });
+
+      test('should set viewPort with correct args', async () => {
+        const options = {
+          viewportSize: {
+            width: 320,
+            height: 568
+          }
+        };
+
+        await internals.generate(url, options);
+        expect(page.setViewport.calledOnceWith({ width: 320, height: 568 })).toBe(true);
       });
     });
   });


### PR DESCRIPTION
- It takes WIDTHxHEIGHT as an argument.
- It blows up if format is not correct.
- It sets the ViewportSize of the page.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
I want to be able to profile in different viewports, for e.g. mobile.

## How Has This Been Tested?

```
node bin/index.js generate https://m.reddit.com --viewport-size '320x568' --screenshots
```

## Screenshots (if appropriate):

<img width="1409" alt="Screen Shot 2019-03-12 at 9 56 39 pm" src="https://user-images.githubusercontent.com/19025/54195024-c0a04400-4511-11e9-932e-bdd050214c49.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. 
^^ please feedback.
- [ ] I have updated the documentation (if required).
^^ please feedback on the option I added so I can create docs for it.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
