### PR TITLE
Add more launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,22 @@ Documentation](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md
 * `--ignore-https-errors` (optional; `false`) - When `--ignore-https-errors` is passed, an HTTPS
 errors will be ignored. This causes Chrome's default error behaviors when encountering HTTPS issues
 to be ignored.
-* `--headless` (options; `true`) - By default, Perf Timeline CLI runs in "[headless](https://developers.google.com/web/updates/2017/04/headless-chrome)" mode (i.e., without a visible
+* `--headless` (optional; `true`) - By default, Perf Timeline CLI runs in "[headless](https://developers.google.com/web/updates/2017/04/headless-chrome)" mode (i.e., without a visible
 browser UI). To see a browser UI when generating the timeline, pass the `--headless false` to the
 `generate` command. Please note that `--no-headless` is a synonym for `--headless false`.
+* `--executable-path` (optional; `null`) - Define a path to run a specific Chrome or Chromium
+executable. By default, the bundled Chromium, which is the optimal executable for Puppeteer will be
+used to generate the timeline. If you prefer a specific executable, you can define the path to the
+file here.
+* `--slow-mo` (optional; `0`) - Number of milliseconds to slow down the Puppeteer steps. This adds
+a timeout between Puppeteer steps and is primary used for debugging to allow you to make
+observations between steps. Please note that this could potentially cause inaccurate timelines to be
+generated.
+* `--args` (options; `''`) - Additional flag arguments that can be passed to the browser instance
+when starting it. There are a [number of flags](https://peter.sh/experiments/chromium-command-line-switches/)
+that can be passed. The flags should be passed as a comma separated list, e.g.,
+`--args="--disable-gpu,--video-threads=5"`. Due to the sheer volume of possible flags, not all can
+be verified. Your mileage may vary.
 
 ### Network Emulation Options
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Launch options are passed to the `puppeteer.launch()` command. Not all options a
 supported. Supported options are listed below. For more information, please see the [Puppeteer
 Documentation](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#puppeteerlaunchoptions).
 
-* `--ignore-https-errors` (optional; `false`) - When `--ignore-https-errors` is passed, an HTTPS
+* `--ignore-https-errors` (optional; `false`) - When `--ignore-https-errors` is passed, all HTTPS
 errors will be ignored. This causes Chrome's default error behaviors when encountering HTTPS issues
 to be ignored.
 * `--headless` (optional; `true`) - By default, Perf Timeline CLI runs in "[headless](https://developers.google.com/web/updates/2017/04/headless-chrome)" mode (i.e., without a visible

--- a/README.md
+++ b/README.md
@@ -128,6 +128,37 @@ when starting it. There are a [number of flags](https://peter.sh/experiments/chr
 that can be passed. The flags should be passed as a comma separated list, e.g.,
 `--args="--disable-gpu,--video-threads=5"`. Due to the sheer volume of possible flags, not all can
 be verified. Your mileage may vary.
+* `--ignore-default-args` (optional; `false`) - Passing this flag will ignore Puppeteer's default
+args for launching Chrome.
+* `--handle-sigint` (optional; `true`) - Setting this to `false` or passing `--no-handle-sigint`
+will cause Puppeteer to ignore the closing the browser on Ctrl-C. By default, the browser is closed
+on Ctrl-C.
+* `--handle-sigterm` (optional; `true`) - Setting this to `false` or passing `--no-handle-sigterm`
+will cause Puppeteer to ignore the closing the browser on SIGTERM. By default, the browser is closed
+on SIGTERM.
+* `--handle-sighup` (optional; `true`) - Setting this to `false` or passing `--no-handle-sighup`
+will cause Puppeteer to ignore the closing the browser on SIGHUP. By default, the browser is closed
+on SIGHUP.
+* `--launch-timeout` (optional; `30000`) - Amount of time in milliseconds to allow the browser to
+launch before timing out. Note that the name of this arg diverges from Puppeteer's due to a name
+collision with another argument.
+* `--dumpio` (optional; `false`) - Determines whether or not to send the browser process' stdout and
+stderr to the terminal. Setting this argument to `true` will show the console information in the
+terminal session.
+* `--user-data-dir` (optional; `''`) - The path to the user directory that you wish you use while
+creating the timeline.
+* `--env` (optional: `process.env`) - The `env` argument allows you to specify environment variables
+to use for the browser session. By default, it will read from `process.env`. However, if you wish
+to pass variables into the tool via command args, you can do so via the `env` arg. The value must be
+a valid JSON string. For instance, `--env='{"foo":"bar","biz":{"boz":"buz"}}'`. Since the default is
+to use `process.env`, you can pass arguments via traditional environment variables. This interface
+is optional and allows for greater flexibility.
+* `--devtools` (optional; `false`) - Passing this flag will open a DevTools tab when
+using Perf Timeline in non-headless mode. Note that if page execution is really fast, this option
+won't do much. You can slow down execution using the `--slow-mo` arg. A reasonable way to use this
+arg would to do something like: `--slow-mo 2000 --no-headless --devtools`.
+* `--pipe` (optional; `false`) - Passing this flag causes Puppeteer to use a pipe to connect to the
+browser instead of the default web socket method.
 
 ### Network Emulation Options
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ file here.
 a timeout between Puppeteer steps and is primary used for debugging to allow you to make
 observations between steps. Please note that this could potentially cause inaccurate timelines to be
 generated.
+* `--launch-default-viewport-width` (optional; `800`) - The viewport width in pixels
+* `--launch-default-viewport-height` (optional; `600`) - The viewport height in pixels
+* `--launch-default-viewport-device-scale-factor` (optional; `1`) - Device pixel ratio for the current page
+* `--launch-default-viewport-is-mobile` (optional; `false`) - Whether or note the `meta viewport` tag is taken into account
+* `--launch-default-viewport-has-touch` (optional; `false`) - Specifies if viewport supports touch events
+* `--launch-default-viewport-is-landscape` (optional; `false`) - Specifies if viewport is in landscape mode
 * `--args` (options; `''`) - Additional flag arguments that can be passed to the browser instance
 when starting it. There are a [number of flags](https://peter.sh/experiments/chromium-command-line-switches/)
 that can be passed. The flags should be passed as a comma separated list, e.g.,

--- a/package-lock.json
+++ b/package-lock.json
@@ -577,9 +577,9 @@
       "dev": true
     },
     "agent-base": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -1023,8 +1023,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -1275,6 +1274,17 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -1569,9 +1579,9 @@
       }
     },
     "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -2058,34 +2068,14 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
+        "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
       }
     },
     "extsprintf": {
@@ -2484,21 +2474,26 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
-      "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -4171,9 +4166,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
     },
     "mime-db": {
       "version": "1.38.0",
@@ -4234,7 +4229,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -4768,7 +4762,8 @@
     "progress": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
     },
     "prompts": {
       "version": "2.0.4",
@@ -4807,28 +4802,44 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.2.0.tgz",
-      "integrity": "sha512-4sY/6mB7+kNPGAzPGKq65tH0VG3ohUEkXHuOReB9K/tw3m1TqifYmxnMR/uDeci/UPwyk5K1gWYh8rw0U0Zscw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.13.0.tgz",
+      "integrity": "sha512-LUXgvhjfB/P6IOUDAKxOcbCz9ISwBLL9UpKghYrcBDwrOGx1m60y0iN2M64mdAUbT4+7oZM5DTxOW7equa2fxQ==",
       "requires": {
-        "debug": "^2.6.8",
-        "extract-zip": "^1.6.5",
-        "https-proxy-agent": "^2.1.0",
-        "mime": "^1.3.4",
-        "progress": "^2.0.0",
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
-        "ws": "^3.0.0"
+        "ws": "^6.1.0"
       },
       "dependencies": {
-        "ws": {
-          "version": "3.3.3",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+        },
+        "ws": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
+          "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
+          "requires": {
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -5933,11 +5944,6 @@
           "optional": true
         }
       }
-    },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "union-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "acorn": "6.1.1",
+    "camelcase": "5.2.0",
     "eslint": "5.15.3",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.16.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "cli-logger": "^0.5.40",
-    "puppeteer": "^1.2.0",
+    "puppeteer": "^1.3.0",
     "yargs": "^13.0.0"
   },
   "bin": {

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -89,6 +89,12 @@ const OPTIONS = {
     describe: 'Whether to pipe the browser process stdout and stderr into process.stdout and process.stderr',
     group: 'Launch'
   },
+  'user-data-dir': {
+    default: '',
+    type: 'string',
+    describe: 'Path to a User Data Directory',
+    group: 'Launch'
+  },
 
   // Network emulation options
   'emulate-network-conditions': {

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -33,6 +33,62 @@ const OPTIONS = {
     describe: 'Whether to run browser in headless mode',
     group: 'Launch'
   },
+  'executable-path': {
+    default: null, // Empty string will throw an error in Puppeteer
+    type: 'string',
+    describe: 'Path to a Chromium or Chrome executable to run instead of the bundled Chromium',
+    group: 'Launch'
+  },
+  'slow-mo': {
+    default: 0,
+    type: 'number',
+    describe: 'Slows down Puppeteer operations by the specified amount of milliseconds',
+    group: 'Launch'
+  },
+  args: {
+    default: [],
+    type: 'array',
+    describe: 'Additional arguments to pass to the browser instance',
+    group: 'Launch'
+  },
+  'ignore-default-args': {
+    default: false,
+    type: 'boolean',
+    describe: 'Do not use Puppeteer\'s defaultArgs object',
+    group: 'Launch'
+  },
+  'handle-sigint': {
+    default: true,
+    type: 'boolean',
+    describe: 'Close the browser process on Ctrl-C',
+    group: 'Launch'
+  },
+  'handle-sigterm': {
+    default: true,
+    type: 'boolean',
+    describe: 'Close the browser process on SIGTERM',
+    group: 'Launch'
+  },
+  'handle-sighup': {
+    default: true,
+    type: 'boolean',
+    describe: 'Close the browser process on SIGHUP',
+    group: 'Launch'
+  },
+
+  // @todo: naming conflict
+  timeout: {
+    default: 30000,
+    type: 'number',
+    describe: 'Maximum time in milliseconds to wait for the browser instance to start',
+    group: 'Launch'
+  },
+  dumpio: {
+    default: false,
+    type: 'boolean',
+    describe: 'Whether to pipe the browser process stdout and stderr into process.stdout and process.stderr',
+    group: 'Launch'
+  },
 
   // Network emulation options
   'emulate-network-conditions': {

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -1,4 +1,4 @@
-const { megabitsToBytes } = require('../../utils/general');
+const { maybeStringToJson, megabitsToBytes } = require('../../utils/general');
 
 const CONNECTION_TYPES = [
   'none',
@@ -73,6 +73,19 @@ const OPTIONS = {
     default: true,
     type: 'boolean',
     describe: 'Close the browser process on SIGHUP',
+    group: 'Launch'
+  },
+  env: {
+    default: process.env,
+    type: 'string',
+    describe: 'Specify environment variables that will be visible to the browser',
+    group: 'Launch',
+    coerce: maybeStringToJson
+  },
+  devtools: {
+    default: false,
+    type: 'boolean',
+    describe: 'Whether to auto-open a DevTools panel for each tab',
     group: 'Launch'
   },
 

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -75,19 +75,6 @@ const OPTIONS = {
     describe: 'Close the browser process on SIGHUP',
     group: 'Launch'
   },
-  env: {
-    default: process.env,
-    type: 'string',
-    describe: 'Specify environment variables that will be visible to the browser',
-    group: 'Launch',
-    coerce: maybeStringToJson
-  },
-  devtools: {
-    default: false,
-    type: 'boolean',
-    describe: 'Whether to auto-open a DevTools panel for each tab',
-    group: 'Launch'
-  },
   'launch-timeout': {
     default: 30000,
     type: 'number',
@@ -104,6 +91,25 @@ const OPTIONS = {
     default: '',
     type: 'string',
     describe: 'Path to a User Data Directory',
+    group: 'Launch'
+  },
+  env: {
+    default: process.env,
+    type: 'string',
+    describe: 'Specify environment variables that will be visible to the browser',
+    group: 'Launch',
+    coerce: maybeStringToJson
+  },
+  devtools: {
+    default: false,
+    type: 'boolean',
+    describe: 'Whether to auto-open a DevTools panel for each tab',
+    group: 'Launch'
+  },
+  pipe: {
+    default: false,
+    type: 'boolean',
+    describe: 'Connects to the browser over a pipe instead of a WebSocket',
     group: 'Launch'
   },
 

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -88,9 +88,7 @@ const OPTIONS = {
     describe: 'Whether to auto-open a DevTools panel for each tab',
     group: 'Launch'
   },
-
-  // @todo: naming conflict
-  timeout: {
+  'launch-timeout': {
     default: 30000,
     type: 'number',
     describe: 'Maximum time in milliseconds to wait for the browser instance to start',

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -21,55 +21,55 @@ const WAIT_UNTIL_OPTIONS = [
 
 const OPTIONS = {
   // Launch options
-  'ignore-https-errors': {
+  'launch-ignore-https-errors': {
     default: false,
     type: 'boolean',
     describe: 'Whether to ignore HTTPS errors during navigation',
     group: 'Launch'
   },
-  headless: {
+  'launch-headless': {
     default: true,
     type: 'boolean',
     describe: 'Whether to run browser in headless mode',
     group: 'Launch'
   },
-  'executable-path': {
+  'launch-executable-path': {
     default: null, // Empty string will throw an error in Puppeteer
     type: 'string',
     describe: 'Path to a Chromium or Chrome executable to run instead of the bundled Chromium',
     group: 'Launch'
   },
-  'slow-mo': {
+  'launch-slow-mo': {
     default: 0,
     type: 'number',
     describe: 'Slows down Puppeteer operations by the specified amount of milliseconds',
     group: 'Launch'
   },
-  args: {
+  'launch-args': {
     default: [],
     type: 'array',
     describe: 'Additional arguments to pass to the browser instance',
     group: 'Launch'
   },
-  'ignore-default-args': {
+  'launch-ignore-default-args': {
     default: false,
     type: 'boolean',
     describe: 'Do not use Puppeteer\'s defaultArgs object',
     group: 'Launch'
   },
-  'handle-sigint': {
+  'launch-handle-sigint': {
     default: true,
     type: 'boolean',
     describe: 'Close the browser process on Ctrl-C',
     group: 'Launch'
   },
-  'handle-sigterm': {
+  'launch-handle-sigterm': {
     default: true,
     type: 'boolean',
     describe: 'Close the browser process on SIGTERM',
     group: 'Launch'
   },
-  'handle-sighup': {
+  'launch-handle-sighup': {
     default: true,
     type: 'boolean',
     describe: 'Close the browser process on SIGHUP',
@@ -81,32 +81,32 @@ const OPTIONS = {
     describe: 'Maximum time in milliseconds to wait for the browser instance to start',
     group: 'Launch'
   },
-  dumpio: {
+  'launch-dumpio': {
     default: false,
     type: 'boolean',
     describe: 'Whether to pipe the browser process stdout and stderr into process.stdout and process.stderr',
     group: 'Launch'
   },
-  'user-data-dir': {
+  'launch-user-data-dir': {
     default: '',
     type: 'string',
     describe: 'Path to a User Data Directory',
     group: 'Launch'
   },
-  env: {
+  'launch-env': {
     default: process.env,
     type: 'string',
     describe: 'Specify environment variables that will be visible to the browser',
     group: 'Launch',
     coerce: maybeStringToJson
   },
-  devtools: {
+  'launch-devtools': {
     default: false,
     type: 'boolean',
     describe: 'Whether to auto-open a DevTools panel for each tab',
     group: 'Launch'
   },
-  pipe: {
+  'launch-pipe': {
     default: false,
     type: 'boolean',
     describe: 'Connects to the browser over a pipe instead of a WebSocket',

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -45,6 +45,42 @@ const OPTIONS = {
     describe: 'Slows down Puppeteer operations by the specified amount of milliseconds',
     group: 'Launch'
   },
+  'launch-default-viewport-width': {
+    default: 800,
+    type: 'number',
+    describe: 'Viewport width in pixels',
+    group: 'Launch'
+  },
+  'launch-default-viewport-height': {
+    default: 600,
+    type: 'number',
+    describe: 'Viewport height in pixels',
+    group: 'Launch'
+  },
+  'launch-default-viewport-device-scale-factor': {
+    default: 1,
+    type: 'number',
+    describe: 'Specify device scale factor (can be thought of as DPR)',
+    group: 'Launch'
+  },
+  'launch-default-viewport-is-mobile': {
+    default: false,
+    type: 'boolean',
+    describe: 'Whether the meta viewport tag is taken into account',
+    group: 'Launch'
+  },
+  'launch-default-viewport-has-touch': {
+    default: false,
+    type: 'boolean',
+    describe: 'Specifies if viewport supports touch events',
+    group: 'Launch'
+  },
+  'launch-default-viewport-is-landscape': {
+    default: false,
+    type: 'boolean',
+    describe: 'Specifies if viewport is in landscape mode',
+    group: 'Launch'
+  },
   'launch-args': {
     default: [],
     type: 'array',

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -9,7 +9,16 @@ internals.generate = async (url = '', options = {}) => {
   const { die } = dieModule;
   const browser = await puppeteer.launch({
     ignoreHTTPSErrors: options.ignoreHTTPSErrors,
-    headless: options.headless
+    headless: options.headless,
+    executablePath: options.executablePath,
+    slowMo: options.slowMo,
+    args: options.args,
+    ignoreDefaultArgs: options.ignoreDefaultArgs,
+    handleSIGINT: options.handleSigint,
+    handleSIGTERM: options.handleSigterm,
+    handleSIGHUP: options.handleSighup,
+    timeout: options.timeout,
+    dumpio: options.dumpio
   });
   const page = await browser.newPage();
 

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -18,7 +18,8 @@ internals.generate = async (url = '', options = {}) => {
     handleSIGTERM: options.handleSigterm,
     handleSIGHUP: options.handleSighup,
     timeout: options.timeout,
-    dumpio: options.dumpio
+    dumpio: options.dumpio,
+    userDataDir: options.userDataDir
   });
   const page = await browser.newPage();
 

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -17,11 +17,12 @@ internals.generate = async (url = '', options = {}) => {
     handleSIGINT: options.handleSigint,
     handleSIGTERM: options.handleSigterm,
     handleSIGHUP: options.handleSighup,
-    timeout: options.timeout,
+    timeout: options.launchTimeout, // Note the naming difference due to "timeout" name collision
     dumpio: options.dumpio,
     userDataDir: options.userDataDir,
     env: options.env,
-    devtools: options.devtools
+    devtools: options.devtools,
+    pipe: options.pipe
   });
   const page = await browser.newPage();
 

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -19,7 +19,9 @@ internals.generate = async (url = '', options = {}) => {
     handleSIGHUP: options.handleSighup,
     timeout: options.timeout,
     dumpio: options.dumpio,
-    userDataDir: options.userDataDir
+    userDataDir: options.userDataDir,
+    env: options.env,
+    devtools: options.devtools
   });
   const page = await browser.newPage();
 

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -8,21 +8,21 @@ const internals = {};
 internals.generate = async (url = '', options = {}) => {
   const { die } = dieModule;
   const browser = await puppeteer.launch({
-    ignoreHTTPSErrors: options.ignoreHTTPSErrors,
-    headless: options.headless,
-    executablePath: options.executablePath,
-    slowMo: options.slowMo,
-    args: options.args,
-    ignoreDefaultArgs: options.ignoreDefaultArgs,
-    handleSIGINT: options.handleSigint,
-    handleSIGTERM: options.handleSigterm,
-    handleSIGHUP: options.handleSighup,
+    ignoreHTTPSErrors: options.launchIgnoreHTTPSErrors,
+    headless: options.launchHeadless,
+    executablePath: options.launchExecutablePath,
+    slowMo: options.launchSlowMo,
+    args: options.launchArgs,
+    ignoreDefaultArgs: options.launchIgnoreDefaultArgs,
+    handleSIGINT: options.launchHandleSigint,
+    handleSIGTERM: options.launchHandleSigterm,
+    handleSIGHUP: options.launchHandleSighup,
     timeout: options.launchTimeout, // Note the naming difference due to "timeout" name collision
-    dumpio: options.dumpio,
-    userDataDir: options.userDataDir,
-    env: options.env,
-    devtools: options.devtools,
-    pipe: options.pipe
+    dumpio: options.launchDumpio,
+    userDataDir: options.launchUserDataDir,
+    env: options.launchEnv,
+    devtools: options.launchDevtools,
+    pipe: options.launchPipe
   });
   const page = await browser.newPage();
 

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -12,6 +12,14 @@ internals.generate = async (url = '', options = {}) => {
     headless: options.launchHeadless,
     executablePath: options.launchExecutablePath,
     slowMo: options.launchSlowMo,
+    defaultViewport: {
+      width: options.launchDefaultViewportWidth,
+      height: options.launchDefaultViewportHeight,
+      deviceScaleFactor: options.launchDefaultViewportDeviceScaleFactor,
+      isMobile: options.launchDefaultViewportIsMobile,
+      hasTouch: options.launchDefaultViewportHasTouch,
+      isLandscape: options.launchDefaultViewportIsLandscape
+    },
     args: options.launchArgs,
     ignoreDefaultArgs: options.launchIgnoreDefaultArgs,
     handleSIGINT: options.launchHandleSigint,

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -1,3 +1,5 @@
+const dieModule = require('./die');
+
 /**
  * Converts megabits to bytes.
  *
@@ -14,6 +16,39 @@
  */
 const megabitsToBytes = megabits => (megabits * 1024 * 1024) / 8;
 
+// h/t https://stackoverflow.com/a/33369954
+const isJson = (item) => {
+  let value = (typeof item !== 'string') ? JSON.stringify(item) : item;
+
+  try {
+    value = JSON.parse(value);
+  } catch (e) {
+    return false;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    return true;
+  }
+
+  return false;
+};
+
+const maybeStringToJson = (value) => {
+  const { die } = dieModule;
+
+  if (isJson(value)) {
+    return value;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (err) {
+    die(err);
+  }
+};
+
 module.exports = {
+  isJson,
+  maybeStringToJson,
   megabitsToBytes
 };

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -16,7 +16,14 @@ const dieModule = require('./die');
  */
 const megabitsToBytes = megabits => (megabits * 1024 * 1024) / 8;
 
-// h/t https://stackoverflow.com/a/33369954
+/**
+ * Determine if value if valid JSON.
+ *
+ * Ref: https://stackoverflow.com/a/33369954
+ *
+ * @param {*} item - Value to test.
+ * @returns {bool} Whether or not the value is parsable JSON.
+ */
 const isJson = (item) => {
   let value = (typeof item !== 'string') ? JSON.stringify(item) : item;
 
@@ -33,18 +40,37 @@ const isJson = (item) => {
   return false;
 };
 
+/**
+ * Convert value to JSON if possible.
+ *
+ * The main purpose of this function is turning JSON-like data into a JavaScript object for use as
+ * args. It enables users to pass in a JSON string as input and allow for conversion to an object
+ * to be used as an argument.
+ *
+ * @param {*} value - Value to convert to a JS object.
+ * @returns {object} The input value converted to a JS object.
+ */
 const maybeStringToJson = (value) => {
   const { die } = dieModule;
+  let result = value;
 
-  if (isJson(value)) {
-    return value;
+  // If the value is a JSON-like JS object, it can be returned early
+  if (isJson(value) && typeof value === 'object') {
+    return result;
   }
 
   try {
-    return JSON.parse(value);
+    // If it parses into a JS object, it is JSON-like enough to use
+    result = JSON.parse(value);
+
+    if (typeof result !== 'object') {
+      throw new Error('string cannot be converted to object');
+    }
   } catch (err) {
     die(err);
   }
+
+  return result;
 };
 
 module.exports = {

--- a/test/helper/args.js
+++ b/test/helper/args.js
@@ -1,0 +1,31 @@
+const camelCase = require('camelcase');
+
+const bool = (cli, name) => {
+  let camel;
+
+  beforeEach(() => {
+    camel = camelCase(name);
+  });
+
+  test('should return true', () => {
+    const output = cli.parse(`generate url --${name}`);
+    expect(output[name]).toBe(true);
+    expect(output[camel]).toBe(true);
+  });
+
+  test('should be false by default', () => {
+    const output = cli.parse('generate url');
+    expect(output[name]).toBe(false);
+    expect(output[camel]).toBe(false);
+  });
+
+  test('should be false when the no variant is passed', () => {
+    const output = cli.parse(`generate url --no-${name}`);
+    expect(output[name]).toBe(false);
+    expect(output[camel]).toBe(false);
+  });
+};
+
+module.exports = {
+  bool
+};

--- a/test/helper/test-handler.js
+++ b/test/helper/test-handler.js
@@ -1,0 +1,17 @@
+/**
+ * Passthrough handler that returns the args passed to it.
+ *
+ * This method allows setting up commands for testing. It ultimately allows for testing that the
+ * builder interface produces the correct arguments for the handler. The method simply returns the
+ * arguments passed to it. As such, one can compose a test where a command it set up with a builder,
+ * this passthrough handler, and args for testing. By testing the the output of the handler, the
+ * builder setup can be tested.
+ *
+ * @param {object} argv - The arguments passed to the command.
+ * @returns {object} Passthrough arguments passed to the command.
+ */
+const handler = argv => argv;
+
+module.exports = {
+  handler
+};

--- a/test/integration/commands/generate.spec.js
+++ b/test/integration/commands/generate.spec.js
@@ -1,0 +1,33 @@
+const yargs = require('yargs');
+
+const { builder, command, desc } = require('../../../src/commands/generate');
+const { handler } = require('../../helper/test-handler');
+
+// Set up the fake test command
+const testCommand = {
+  builder,
+  command,
+  desc,
+  handler
+};
+
+const cli = yargs.command(testCommand);
+
+describe.only('src/commands/generate', () => {
+  describe('ignore-https-errors', () => {
+    test('should return true', () => {
+      const output = cli.parse('generate url --ignore-https-errors');
+      expect(output.ignoreHttpsErrors).toBe(true);
+    });
+
+    test('should be false by default', () => {
+      const output = cli.parse('generate url');
+      expect(output.ignoreHttpsErrors).toBe(false);
+    });
+
+    test('should be false when the no variant is passed', () => {
+      const output = cli.parse('generate url --no-ignore-https-errors');
+      expect(output.ignoreHttpsErrors).toBe(false);
+    });
+  });
+});

--- a/test/integration/commands/generate.spec.js
+++ b/test/integration/commands/generate.spec.js
@@ -1,5 +1,7 @@
 const yargs = require('yargs');
 
+const { bool } = require('../../helper/args');
+
 const { builder, command, desc } = require('../../../src/commands/generate');
 const { handler } = require('../../helper/test-handler');
 
@@ -15,19 +17,6 @@ const cli = yargs.command(testCommand);
 
 describe.only('src/commands/generate', () => {
   describe('ignore-https-errors', () => {
-    test('should return true', () => {
-      const output = cli.parse('generate url --ignore-https-errors');
-      expect(output.ignoreHttpsErrors).toBe(true);
-    });
-
-    test('should be false by default', () => {
-      const output = cli.parse('generate url');
-      expect(output.ignoreHttpsErrors).toBe(false);
-    });
-
-    test('should be false when the no variant is passed', () => {
-      const output = cli.parse('generate url --no-ignore-https-errors');
-      expect(output.ignoreHttpsErrors).toBe(false);
-    });
+    bool(cli, 'ignore-https-errors');
   });
 });

--- a/test/integration/commands/generate.spec.js
+++ b/test/integration/commands/generate.spec.js
@@ -16,7 +16,7 @@ const testCommand = {
 const cli = yargs.command(testCommand);
 
 describe.only('src/commands/generate', () => {
-  describe('ignore-https-errors', () => {
-    bool(cli, 'ignore-https-errors');
+  describe('launch-ignore-https-errors', () => {
+    bool(cli, 'launch-ignore-https-errors');
   });
 });

--- a/test/src/utils/general.spec.js
+++ b/test/src/utils/general.spec.js
@@ -1,0 +1,108 @@
+const sinon = require('sinon');
+
+const die = require('../../../src/utils/die');
+const general = require('../../../src/utils/general');
+
+const sandbox = sinon.createSandbox();
+
+describe('src/utils/general', () => {
+  describe('megabitsToBytes', () => {
+    test('should convert number to correct value', () => {
+      const megabits = 1.6;
+      const actual = general.megabitsToBytes(megabits);
+      const expected = 209715.2;
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('isJson', () => {
+    describe('valid JSON cases', () => {
+      test('should be true when empty object is passed', () => {
+        const item = {};
+        const expected = true;
+        const actual = general.isJson(item);
+        expect(actual).toBe(expected);
+      });
+
+      test('should be true when non empty object is passed', () => {
+        const item = { foo: 'bar' };
+        const expected = true;
+        const actual = general.isJson(item);
+        expect(actual).toBe(expected);
+      });
+    });
+
+    describe('invalid JSON cases', () => {
+      test('should be false when an empty string is passed', () => {
+        const item = '';
+        const expected = false;
+        const actual = general.isJson(item);
+        expect(actual).toBe(expected);
+      });
+
+      test('should be false when a number is passed', () => {
+        const item = 5;
+        const expected = false;
+        const actual = general.isJson(item);
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('maybeStringToJson', () => {
+    let dieStub;
+
+    beforeEach(() => {
+      dieStub = sandbox.stub(die, 'die');
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    test('should return input if it is an empty js object', () => {
+      const item = {};
+      const expected = item;
+      const actual = general.maybeStringToJson(item);
+      expect(actual).toBe(expected);
+    });
+
+    test('should return input if it is a js object', () => {
+      const item = { foo: 'bar' };
+      const expected = item;
+      const actual = general.maybeStringToJson(item);
+      expect(actual).toBe(expected);
+    });
+
+    test('should die when passed non-JSON string', () => {
+      const item = 'foo';
+      general.maybeStringToJson(item);
+      expect(dieStub.calledOnce).toBe(true);
+    });
+
+    test('should die when passed number', () => {
+      const item = 10;
+      general.maybeStringToJson(item);
+      expect(dieStub.calledOnce).toBe(true);
+    });
+
+    test('should return js object when JSON string is passed', () => {
+      const item = '{"test":"value"}';
+      const expected = JSON.parse(item);
+      const actual = general.maybeStringToJson(item);
+      expect(actual).toEqual(expected);
+    });
+
+    test('should return value when JSON string contains non-string key', () => {
+      const item = '{test:"value"}';
+      general.maybeStringToJson(item);
+      expect(dieStub.calledOnce).toBe(true);
+    });
+
+    test('should return value when JSON string contains badly quoted key', () => {
+      const item = '{\'test\':"value"}';
+      general.maybeStringToJson(item);
+      expect(dieStub.calledOnce).toBe(true);
+    });
+  });
+});

--- a/test/unit/src/commands/generate.spec.js
+++ b/test/unit/src/commands/generate.spec.js
@@ -1,4 +1,4 @@
-const generate = require('../../../src/commands/generate');
+const generate = require('../../../../src/commands/generate');
 
 describe('src/commands/generate', () => {
   describe('command', () => {

--- a/test/unit/src/commands/generate/builder.spec.js
+++ b/test/unit/src/commands/generate/builder.spec.js
@@ -1,4 +1,4 @@
-const { builder } = require('../../../../src/commands/generate/builder');
+const { builder } = require('../../../../../src/commands/generate/builder');
 
 describe('src/commands/generate/builder', () => {
   test('should export options with required properties', () => {

--- a/test/unit/src/commands/generate/handler.spec.js
+++ b/test/unit/src/commands/generate/handler.spec.js
@@ -4,9 +4,9 @@ const sinon = require('sinon');
 const {
   __internals__: internals,
   handler
-} = require('../../../../src/commands/generate/handler');
-const client = require('../../../../src/utils/client');
-const die = require('../../../../src/utils/die');
+} = require('../../../../../src/commands/generate/handler');
+const client = require('../../../../../src/utils/client');
+const die = require('../../../../../src/utils/die');
 
 const sandbox = sinon.createSandbox();
 

--- a/test/unit/src/utils/client.spec.js
+++ b/test/unit/src/utils/client.spec.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 
-const { buildCommand, send } = require('../../../src/utils/client');
+const { buildCommand, send } = require('../../../../src/utils/client');
 
 const sandbox = sinon.createSandbox();
 

--- a/test/unit/src/utils/die.spec.js
+++ b/test/unit/src/utils/die.spec.js
@@ -1,7 +1,7 @@
 const sinon = require('sinon');
 
-const { die } = require('../../../src/utils/die');
-const logger = require('../../../src/utils/logger');
+const { die } = require('../../../../src/utils/die');
+const logger = require('../../../../src/utils/logger');
 
 const sandbox = sinon.createSandbox();
 

--- a/test/unit/src/utils/general.spec.js
+++ b/test/unit/src/utils/general.spec.js
@@ -1,7 +1,7 @@
 const sinon = require('sinon');
 
-const die = require('../../../src/utils/die');
-const general = require('../../../src/utils/general');
+const die = require('../../../../src/utils/die');
+const general = require('../../../../src/utils/general');
 
 const sandbox = sinon.createSandbox();
 

--- a/test/unit/src/utils/generate.spec.js
+++ b/test/unit/src/utils/generate.spec.js
@@ -1,4 +1,4 @@
-const general = require('../../../src/utils/general');
+const general = require('../../../../src/utils/general');
 
 describe('src/utils/general', () => {
   test('should convert number to correct value', () => {

--- a/test/unit/src/utils/logger.spec.js
+++ b/test/unit/src/utils/logger.spec.js
@@ -1,4 +1,4 @@
-const { logger } = require('../../../src/utils/logger');
+const { logger } = require('../../../../src/utils/logger');
 
 describe('src/utils/logger', () => {
   test('should export an object', () => {


### PR DESCRIPTION
Adds support for all launch options available as of Puppeteer 1.2.0. Goal is to support the Puppeteer APIs to give the same control you'd have if you were interacting with Puppeteer directly.

## Description

The bulk of this work is adding new yargs args to interface, parsing the args, and routing them to the `puppeteer.launch` method.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

https://github.com/CondeNast/perf-timeline-cli/pull/12

## Motivation and Context

For this tool to be useful, we need to add more ways to configure the timeline generator. As much as possible, we should aim for command option parity with Puppeteer's launch method.

## How Has This Been Tested?

Tests are in the code.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
