### PR TITLE
Add page.setViewport options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 * Added Renovate to ensure dependencies stay up to date ([#15](https://github.com/CondeNast/perf-timeline-cli/issues/15))
+* Added `page.setViewport` args ([#19](https://github.com/CondeNast/perf-timeline-cli/issues/19))
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ unless this flag is set.
 * `--rate` (optional; `1`) - Sets the CPU throttling rate. The number represents the slowdown
 factor (e.g., 2 is a "2x" slowdown).
 
+### Page Options
+
+#### `setViewport` Options
+
+The `setViewport` options mirror the [`page.setViewport()`](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagesetviewportviewport) options in Puppeteer. These options control viewport features of the page under test.
+
+* `--page-set-viewport-width` (optional; `800`) - The viewport width in pixels
+* `--page-set-viewport-height` (optional; `600`) - The viewport height in pixels
+* `--page-set-viewport-device-scale-factor` (optional; `1`) - Device pixel ratio for the current page
+* `--page-set-viewport-is-mobile` (optional; `false`) - Whether or note the `meta viewport` tag is taken into account
+* `--page-set-viewport-has-touch` (optional; `false`) - Specifies if viewport supports touch events
+* `--page-set-viewport-is-landscape` (optional; `false`) - Specifies if viewport is in landscape mode
+
 ### Goto Options
 
 The Goto Options mirror the `page.goto()` method's options from Puppeteer. These options allow you

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -33,7 +33,6 @@ const OPTIONS = {
     describe: 'Whether to run browser in headless mode',
     group: 'Launch'
   },
-
   // Network emulation options
   'emulate-network-conditions': {
     default: false,
@@ -123,6 +122,43 @@ const OPTIONS = {
     type: 'array',
     describe: 'Categories to retrieve from the trace',
     group: 'Tracing options'
+  },
+  // Page.set-viewport
+  'page.set-viewport.width': {
+    default: 800,
+    type: 'number',
+    describe: 'Page width in pixels',
+    group: 'Page'
+  },
+  'page.set-viewport.height': {
+    default: 600,
+    type: 'number',
+    describe: 'Page height in pixels',
+    group: 'Page'
+  },
+  'page.set-viewport.deviceScaleFactor': {
+    default: 1,
+    type: 'number',
+    describe: 'Specify device scale factor (can be thought of as dpr). Defaults to 1',
+    group: 'Page'
+  },
+  'page.set-viewport.isMobile': {
+    default: false,
+    type: 'boolean',
+    describe: 'Whether the meta viewport tag is taken into account. Defaults to false',
+    group: 'Page'
+  },
+  'page.set-viewport.hasTouch': {
+    default: false,
+    type: 'boolean',
+    describe: 'Specifies if viewport supports touch events.',
+    group: 'Page'
+  },
+  'page.set-viewport.isLandscape': {
+    default: false,
+    type: 'boolean',
+    describe: 'Specifies if viewport is in landscape mode.',
+    group: 'Page'
   }
 };
 

--- a/src/commands/generate/builder.js
+++ b/src/commands/generate/builder.js
@@ -33,6 +33,7 @@ const OPTIONS = {
     describe: 'Whether to run browser in headless mode',
     group: 'Launch'
   },
+
   // Network emulation options
   'emulate-network-conditions': {
     default: false,
@@ -123,41 +124,42 @@ const OPTIONS = {
     describe: 'Categories to retrieve from the trace',
     group: 'Tracing options'
   },
+
   // Page.set-viewport
-  'page.set-viewport.width': {
+  'page-set-viewport-width': {
     default: 800,
     type: 'number',
-    describe: 'Page width in pixels',
+    describe: 'Viewport width in pixels',
     group: 'Page'
   },
-  'page.set-viewport.height': {
+  'page-set-viewport-height': {
     default: 600,
     type: 'number',
-    describe: 'Page height in pixels',
+    describe: 'Viewport height in pixels',
     group: 'Page'
   },
-  'page.set-viewport.deviceScaleFactor': {
+  'page-set-viewport-device-scale-factor': {
     default: 1,
     type: 'number',
-    describe: 'Specify device scale factor (can be thought of as dpr). Defaults to 1',
+    describe: 'Specify device scale factor (can be thought of as DPR)',
     group: 'Page'
   },
-  'page.set-viewport.isMobile': {
+  'page-set-viewport-is-mobile': {
     default: false,
     type: 'boolean',
-    describe: 'Whether the meta viewport tag is taken into account. Defaults to false',
+    describe: 'Whether the meta viewport tag is taken into account',
     group: 'Page'
   },
-  'page.set-viewport.hasTouch': {
+  'page-set-viewport-has-touch': {
     default: false,
     type: 'boolean',
-    describe: 'Specifies if viewport supports touch events.',
+    describe: 'Specifies if viewport supports touch events',
     group: 'Page'
   },
-  'page.set-viewport.isLandscape': {
+  'page-set-viewport-is-landscape': {
     default: false,
     type: 'boolean',
-    describe: 'Specifies if viewport is in landscape mode.',
+    describe: 'Specifies if viewport is in landscape mode',
     group: 'Page'
   }
 };

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -13,6 +13,14 @@ internals.generate = async (url = '', options = {}) => {
   });
   const page = await browser.newPage();
 
+  if (options.page && options.page['set-viewport']) {
+    try {
+      await page.setViewport(options.page['set-viewport']);
+    } catch (err) {
+      die(err, browser);
+    }
+  }
+
   if (options.emulateNetworkConditions === true) {
     const command = client.buildCommand('NETWORK', 'EMULATE_NETWORK_CONDITIONS');
 

--- a/src/commands/generate/handler.js
+++ b/src/commands/generate/handler.js
@@ -13,12 +13,17 @@ internals.generate = async (url = '', options = {}) => {
   });
   const page = await browser.newPage();
 
-  if (options.page && options.page['set-viewport']) {
-    try {
-      await page.setViewport(options.page['set-viewport']);
-    } catch (err) {
-      die(err, browser);
-    }
+  try {
+    await page.setViewport({
+      width: options.pageSetViewportWidth,
+      height: options.pageSetViewportHeight,
+      deviceScaleFactor: options.pageSetViewportDeviceScaleFactor,
+      isMobile: options.pageSetViewportIsMobile,
+      hasTouch: options.pageSetViewportHasTouch,
+      isLandscape: options.pageSetViewportIsLandscape
+    });
+  } catch (err) {
+    die(err, browser);
   }
 
   if (options.emulateNetworkConditions === true) {

--- a/test/src/commands/generate/handler.spec.js
+++ b/test/src/commands/generate/handler.spec.js
@@ -24,7 +24,8 @@ describe('src/commands/generate/handler', () => {
           start: sandbox.stub().resolves(),
           stop: sandbox.stub().resolves()
         },
-        goto: sandbox.stub().resolves()
+        goto: sandbox.stub().resolves(),
+        setViewport: sandbox.stub().resolves()
       };
       browser = {
         newPage: sandbox.stub().resolves(page),
@@ -225,6 +226,36 @@ describe('src/commands/generate/handler', () => {
 
         await internals.generate(url, options);
         expect(page.goto.calledOnceWith(url, options)).toBe(true);
+      });
+
+      test('should set page viewport with correct args', async () => {
+        const viewportOptions = {
+          width: 320,
+          height: 568,
+          isMobile: false,
+          hasTouch: false,
+          isLandscape: false
+        };
+        const options = {
+          page: {
+            'set-viewport': viewportOptions
+          }
+        };
+
+        await internals.generate(url, options);
+        expect(page.setViewport.calledOnceWith(viewportOptions)).toBe(true);
+      });
+
+      test('should call die when client set page view port throws an error', async () => {
+        page.setViewport.throws();
+        await internals.generate(url, {
+          page: {
+            'set-viewport': {}
+          }
+        });
+
+        expect(page.setViewport.called).toBe(true);
+        expect(dieStub.called).toBe(true);
       });
     });
   });

--- a/test/src/commands/generate/handler.spec.js
+++ b/test/src/commands/generate/handler.spec.js
@@ -229,21 +229,24 @@ describe('src/commands/generate/handler', () => {
       });
 
       test('should set page viewport with correct args', async () => {
-        const viewportOptions = {
-          width: 320,
-          height: 568,
-          isMobile: false,
-          hasTouch: false,
-          isLandscape: false
-        };
         const options = {
-          page: {
-            'set-viewport': viewportOptions
-          }
+          pageSetViewportWidth: 320,
+          pageSetViewportHeight: 568,
+          pageSetViewportDeviceScaleFactor: 1,
+          pageSetViewportIsMobile: false,
+          pageSetViewportHasTouch: false,
+          pageSetViewportIsLandscape: false
         };
+        const setViewportCallOptions = Object.keys(options)
+          .reduce((acc, key) => {
+            const option = key.replace('pageSetViewport', '');
+            const lsStr = option.charAt(0).toLowerCase() + option.slice(1);
+            acc[lsStr] = options[key];
+            return acc;
+          }, {});
 
         await internals.generate(url, options);
-        expect(page.setViewport.calledOnceWith(viewportOptions)).toBe(true);
+        expect(page.setViewport.calledOnceWith(setViewportCallOptions)).toBe(true);
       });
 
       test('should call die when client set page view port throws an error', async () => {


### PR DESCRIPTION
Implements all of Puppeteers `page.setViewport()`  options.

## Description

The PR allows the CLI to configure all of the values set by `page.setViewport()`. This affords the user the ability to generate different types of page views when generating a timeline.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

This PR is the same as #12, but using a branch off of this fork so the maintainer could edit it.

## Motivation and Context

As @guilherme states:

> I want to be able to profile in different viewports, for e.g. mobile.

## How Has This Been Tested?

Generated timelines and wrote tests. The most complicated piece of this work was figuring out what the args should be named. We opted to go with `page-set-viewport-width` style args as `yargs` has some inconsistencies when handling nested objects, especially with regard to camelcasing. This caused frustration around violated expectations. 

## Screenshots (if appropriate):

N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
